### PR TITLE
Add raylib-assert

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Curated list of awesome stuff for [raylib](https://raylib.com), Simple and easy-
 | [rlobj][158] | [Not-Nik][159] | drop-in replacement for raylib's obj loader. |
 | [Glui][624] | [Samerion][625] | Declarative D user interface library for raylib. |
 | [raylib-api](https://github.com/RobLoach/raylib-api) | [RobLoach](https://github.com/robloach) | Exports of the raylib APIs in different formats (XML, JSON, Lua, etc) |
+| [raylib-assert](https://github.com/RobLoach/raylib-assert) | [RobLoach](https://github.com/robloach) | Runtime assertion library for raylib |
 
 [51]: https://github.com/SasLuca/rayfork
 [52]: https://github.com/SasLuca


### PR DESCRIPTION
[raylib-assert](https://github.com/robloach/raylib-assert) is a runtime assertion library for raylib, allowing quick checks on some of raylib's data structures, leveraging `TraceLog()`.